### PR TITLE
Bug fix/dont throw error flag

### DIFF
--- a/lib/actions/httpRequestAction.ts
+++ b/lib/actions/httpRequestAction.ts
@@ -5,7 +5,7 @@ import { Config, GenericObject, Message, Self } from '../types/global';
 
 async function processAction(this: Self, msg: Message, cfg: Config, snapshot: GenericObject): Promise<void> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const self = wrapper(this, msg as any, cfg, snapshot);
+    const self = wrapper(this, msg as any, cfg);
     self.logger.debug('msg: ', msg);
     self.logger.debug('cfg: ', cfg);
     self.logger.debug('snapshot :', snapshot);

--- a/lib/soapRequest.ts
+++ b/lib/soapRequest.ts
@@ -19,7 +19,7 @@ export async function processMethod(self: Self, msg: Message, cfg: Config, snaps
     const { data } = await axios.post(requestUrl, requestData, {
       headers: formattedHeaders,
     });
-    self.logger.info(`Response: ${data}`);
+    self.logger.debug(`Response: ${data}`);
     if (cfg.saveReceivedData) {
       const response = process.env.ELASTICIO_PUBLISH_MESSAGES_TO ? { data, receivedData: msg.body } : { data, receivedData: msg.data }
       await self.emit('data', newMessage(response));

--- a/lib/triggers/httpRequestTrigger.ts
+++ b/lib/triggers/httpRequestTrigger.ts
@@ -5,7 +5,7 @@ import { Config, GenericObject, Message, Self } from '../types/global';
 
 async function processTrigger(this: Self, msg: Message, cfg: Config, snapshot: GenericObject): Promise<void> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const self = wrapper(this, msg as any, cfg, snapshot);
+    const self = wrapper(this, msg as any, cfg);
     self.logger.debug('msg: ', msg);
     self.logger.debug('cfg: ', cfg);
     self.logger.debug('snapshot :', snapshot);

--- a/lib/types/global.ts
+++ b/lib/types/global.ts
@@ -21,7 +21,7 @@ export interface Config {
     headerName?: string,
     accessToken?: string,
     secretAuthTransform?: string
-    dontThrowErrorFlag?: string
+    dontThrowErrorFlag?: boolean
     namespaces?: Namespace[];
     saveReceivedData?: boolean;
     enableRebound?: boolean;


### PR DESCRIPTION
The SOAP component was not handling errors correctly. Not all errors will have the `response` property, so the conditional check was preventing the error from making it to the `dontThrowErrorFlag` step. Bug fixed and test written. 