### PR TITLE
Log response size and hash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine AS base
+FROM node:14-alpine AS base
 RUN apk --no-cache add \
     python3 \
     make \

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The following is a complete list of configuration fields that are available on t
 
 - **`httpReboundErrorCodes`** - An array of numbers representing http status codes to rebound on if `enableRebound` is set to `true`. Will override the default http response codes.
 
+- **`logResponseHash`** - If set to `true` it will log an md5 hash of the SOAP response at the `info` log level. If set to `false` or not present the hashing step is skipped.
+
 - **`namespaces`** - An array of objects with `name` and `url`. This allows you to add additional namespaces to the SOAP envelope. Ex:
     ```
     config

--- a/lib/soapRequest.ts
+++ b/lib/soapRequest.ts
@@ -27,7 +27,7 @@ export async function processMethod(self: Self, msg: Message, cfg: Config, snaps
         const hash = createHash('md5').update(data).digest('hex');
         self.logger.info(`SOAP response hash: ${hash}`)
       } catch (e) {
-        self.logger.error('Unable to hash SOAP response data');
+        self.logger.error(`Unable to hash SOAP response data: ${e}`);
       }
     }
     if (cfg.saveReceivedData) {

--- a/lib/soapRequest.ts
+++ b/lib/soapRequest.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import axios, { AxiosError } from 'axios';
 import { rateLimit } from './helper';
 import { newMessage } from './messages';
@@ -20,6 +21,15 @@ export async function processMethod(self: Self, msg: Message, cfg: Config, snaps
       headers: formattedHeaders,
     });
     self.logger.debug(`Response: ${data}`);
+    self.logger.info(`SOAP response length: ${data.length}`);
+    if (cfg.logResponseHash) {
+      try {
+        const hash = createHash('md5').update(data).digest('hex');
+        self.logger.info(`SOAP response hash: ${hash}`)
+      } catch (e) {
+        self.logger.error('Unable to hash SOAP response data');
+      }
+    }
     if (cfg.saveReceivedData) {
       const response = process.env.ELASTICIO_PUBLISH_MESSAGES_TO ? { data, receivedData: msg.body } : { data, receivedData: msg.data }
       await self.emit('data', newMessage(response));

--- a/lib/types/global.ts
+++ b/lib/types/global.ts
@@ -27,6 +27,7 @@ export interface Config {
     enableRebound?: boolean;
     httpReboundErrorCodes?: number[];
     rateLimitInMs?: number;
+    logResponseHash?: boolean;
 }
 
 export interface Namespace {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/axios": "^0.14.0",
         "@types/chai": "^4.3.0",
         "@types/mocha": "^9.1.0",
-        "@types/node": "^17.0.12",
+        "@types/node": "^18.0.0",
         "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.10.0",
         "@typescript-eslint/parser": "^5.10.0",
@@ -312,9 +312,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.12.tgz",
-      "integrity": "sha512-4YpbAsnJXWYK/fpTVFlMIcUIho2AYCi4wg5aNPrG1ng7fn/1/RZfCIpRCiBX+12RVa34RluilnvCqD+g3KiSiA==",
+      "version": "18.11.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
+      "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
       "dev": true
     },
     "node_modules/@types/uuid": {
@@ -4533,9 +4533,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.12.tgz",
-      "integrity": "sha512-4YpbAsnJXWYK/fpTVFlMIcUIho2AYCi4wg5aNPrG1ng7fn/1/RZfCIpRCiBX+12RVa34RluilnvCqD+g3KiSiA==",
+      "version": "18.11.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
+      "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
       "dev": true
     },
     "@types/uuid": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/axios": "^0.14.0",
     "@types/chai": "^4.3.0",
     "@types/mocha": "^9.1.0",
-    "@types/node": "^17.0.12",
+    "@types/node": "^18.0.0",
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.10.0",
     "@typescript-eslint/parser": "^5.10.0",


### PR DESCRIPTION
Changes:
- Adds an `info` level log of the SOAP response length
- Adds the config option `logResponseHash` to add an `info` level log of the SOAP response md5 hash

The md5 hash of a response can be calculated by saving the exact response text to a file (`response.xml`), then running this node script:

```js
// md5.js
const crypto = require('crypto');
const fs = require('fs');

const fileContents = fs.readFileSync('response.xml').toString();
const hash = crypto.createHash('md5').update(fileContents).digest('hex');

console.log(`hash: ${hash}`);
```

```sh
node md5.js
# hash: efcc1b4408fda510303993edf2229e6b
```

Closes #19 