### PR TITLE
Removed quotes around auth header auth value

### DIFF
--- a/lib/http.ts
+++ b/lib/http.ts
@@ -10,17 +10,17 @@ export function populateAuthHeaders(auth: Auth, self: Self, bearerToken: string,
       case AuthTypes.BASIC:
           newHeaders.push({
           key: 'Authorization',
-          value: `"Basic ${Buffer.from(
+          value: `Basic ${Buffer.from(
             `${auth.basic?.username}:${auth.basic?.password}`,
             'utf8',
-          ).toString('base64')}"`,
+          ).toString('base64')}`,
         });
         break;
 
       case AuthTypes.API_KEY:
           newHeaders.push({
           key: auth.apiKey?.headerName,
-          value: `"${auth.apiKey?.headerValue}"`,
+          value: `${auth.apiKey?.headerValue}`,
         });
         break;
 
@@ -28,7 +28,7 @@ export function populateAuthHeaders(auth: Auth, self: Self, bearerToken: string,
         self.logger.trace('auth = %j', auth);
         newHeaders.push({
           key: 'Authorization',
-          value: `"Bearer ${bearerToken}"`,
+          value: `Bearer ${bearerToken}`,
         });
         break;
 

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -15,10 +15,10 @@ describe('populateAuthHeaders', () => {
         }
         const headers = populateAuthHeaders(auth, this, bearerToken);
         expect(headers[0].key).to.equal('Authorization')
-        expect(headers[0].value).to.equal(`"Basic ${Buffer.from(
+        expect(headers[0].value).to.equal(`Basic ${Buffer.from(
             `${auth.basic.username}:${auth.basic.password}`,
             'utf8',
-          ).toString('base64')}"`)
+          ).toString('base64')}`)
     })
 
     it('should populate headers for api key', () => {
@@ -31,7 +31,7 @@ describe('populateAuthHeaders', () => {
         }
         const headers = populateAuthHeaders(auth, this, bearerToken);
         expect(headers[0].key).to.equal('dragon')
-        expect(headers[0].value).to.equal('"nighthawk"')
+        expect(headers[0].value).to.equal('nighthawk')
     })
 
     it('should populate headers for oauth', () => {
@@ -47,6 +47,6 @@ describe('populateAuthHeaders', () => {
         }
         const headers = populateAuthHeaders(auth, self, bearerToken);
         expect(headers[0].key).to.equal('Authorization')
-        expect(headers[0].value).to.equal(`"Bearer ${bearerToken}"`);
+        expect(headers[0].value).to.equal(`Bearer ${bearerToken}`);
     })
 })


### PR DESCRIPTION
This was probably adopted from the REST component where you can specify a JSONata transformation.